### PR TITLE
Craft expressive README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # a-repo-for-codex
-simple app for possible consideration of codex pm role, as a repo. &lt;3
+
+> Creating a personal playground for OpenAI PM dreams.
+
+This is a personal project by **Lalo**, crafted for **Codex** while in consideration for the **Product Manager role at OpenAI**. The mission: build a mega app that weaves together magic from every endpoint OpenAI offers, experimenting with ideas that blend creativity, utility, and delightful user experiences.
+
+### Language palette
+<div align="center">
+
+🟥 **Python** 🟦 **JavaScript** 🟩 **TypeScript** 🟨 **Go** 🟪 **Rust**
+
+<br/>
+
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;⬇️&nbsp;🟥 **Python** — the primary canvas for our app experiments.
+
+</div>
+
+### Vision
+- Prototype with every OpenAI endpoint to discover unexpected synergies.
+- Iterate rapidly, embracing playfulness and polish in equal measure.
+- Share learnings, wins, and wild ideas along the way.
+
+Stay tuned as the mega app takes shape—each commit brings us closer to the magic.


### PR DESCRIPTION
## Summary
- rewrite the README to highlight Lalo's Codex project for the OpenAI PM role
- add a colorful language palette that drops Python below the others to mark it as the primary stack
- describe the mega app vision that will explore every OpenAI endpoint

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e45fa12c108329af3e64f858c929dc