### PR TITLE
Add studio workspace with gallery and video composer

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -12,18 +12,33 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
 from .config import BASE_DIR, get_settings
-from .database import Conversation, GalleryAsset, Message, init_db, session_scope
+from .database import (
+    Conversation,
+    Gallery,
+    GalleryAsset,
+    Message,
+    init_db,
+    session_scope,
+)
 from .openai_client import OpenAIMegaClient
 from .schemas import (
     ConversationCreate,
     ConversationRead,
+    GalleryAssetAssignment,
     GalleryAssetCreate,
     GalleryAssetRead,
+    GalleryCreate,
+    GalleryRead,
+    GalleryUpdate,
     ImageRequest,
     ImageResponse,
     MessageCreate,
     MessageRead,
     OpenAIResponse,
+    StudioRenderRequest,
+    StudioRenderResponse,
+    VideoRequest,
+    VideoResponse,
 )
 
 settings = get_settings()
@@ -161,10 +176,158 @@ def generate_image(request: ImageRequest, db=Depends(get_db)):
         title=request.prompt[:80],
         description=f"Generated with {image_info['model']} (quality {request.quality})",
         url=image_info["url"],
-        metadata_json=json.dumps({"revised_prompt": image_info.get("revised_prompt")}),
+        metadata_json=json.dumps(
+            {
+                "revised_prompt": image_info.get("revised_prompt"),
+                "size": request.size,
+                "quality": request.quality,
+                "aspect_ratio": request.aspect_ratio,
+            }
+        ),
     )
     db.add(asset)
     db.flush()
     db.refresh(asset)
 
     return ImageResponse(asset=GalleryAssetRead.model_validate(asset))
+
+
+@app.post("/api/videos", response_model=VideoResponse)
+def generate_video(request: VideoRequest, db=Depends(get_db)):
+    video_info = openai_client.create_video(
+        prompt=request.prompt,
+        aspect_ratio=request.aspect_ratio,
+        duration_seconds=request.duration_seconds,
+        quality=request.quality,
+    )
+
+    asset = GalleryAsset(
+        asset_type="video",
+        title=request.prompt[:80] if request.prompt else "Generated video",
+        description=(
+            f"Storyboard with {video_info['model']} ({request.aspect_ratio}, {request.duration_seconds}s)"
+        ),
+        url=video_info["url"],
+        metadata_json=json.dumps(
+            {
+                "revised_prompt": video_info.get("revised_prompt"),
+                "thumbnail_url": video_info.get("thumbnail_url"),
+                "aspect_ratio": video_info.get("aspect_ratio"),
+                "duration_seconds": video_info.get("duration_seconds"),
+                "quality": video_info.get("quality"),
+                "orientation": video_info.get("orientation"),
+            }
+        ),
+    )
+    db.add(asset)
+    db.flush()
+    db.refresh(asset)
+
+    return VideoResponse(asset=GalleryAssetRead.model_validate(asset))
+
+
+@app.get("/api/galleries", response_model=list[GalleryRead])
+def list_galleries(db=Depends(get_db)):
+    galleries = db.query(Gallery).order_by(Gallery.updated_at.desc()).all()
+    return [GalleryRead.model_validate(gallery) for gallery in galleries]
+
+
+@app.post("/api/galleries", response_model=GalleryRead, status_code=status.HTTP_201_CREATED)
+def create_gallery(payload: GalleryCreate, db=Depends(get_db)):
+    gallery = Gallery(
+        name=payload.name,
+        description=payload.description,
+        category=payload.category,
+        accent_color=payload.accent_color,
+        layout=payload.layout,
+    )
+    db.add(gallery)
+    db.flush()
+    db.refresh(gallery)
+    return GalleryRead.model_validate(gallery)
+
+
+@app.patch("/api/galleries/{gallery_id}", response_model=GalleryRead)
+def update_gallery(gallery_id: int, payload: GalleryUpdate, db=Depends(get_db)):
+    gallery = db.get(Gallery, gallery_id)
+    if gallery is None:
+        raise HTTPException(status_code=404, detail="Gallery not found")
+
+    for field, value in payload.model_dump(exclude_unset=True).items():
+        setattr(gallery, field, value)
+
+    db.flush()
+    db.refresh(gallery)
+    return GalleryRead.model_validate(gallery)
+
+
+@app.post("/api/galleries/{gallery_id}/assets", response_model=GalleryRead)
+def add_asset_to_gallery(gallery_id: int, payload: GalleryAssetAssignment, db=Depends(get_db)):
+    gallery = db.get(Gallery, gallery_id)
+    if gallery is None:
+        raise HTTPException(status_code=404, detail="Gallery not found")
+
+    asset = db.get(GalleryAsset, payload.asset_id)
+    if asset is None:
+        raise HTTPException(status_code=404, detail="Asset not found")
+
+    if asset not in gallery.assets:
+        gallery.assets.append(asset)
+
+    db.flush()
+    db.refresh(gallery)
+    return GalleryRead.model_validate(gallery)
+
+
+@app.get(
+    "/api/galleries/{gallery_id}/assets",
+    response_model=list[GalleryAssetRead],
+)
+def list_gallery_assets(gallery_id: int, db=Depends(get_db)):
+    gallery = db.get(Gallery, gallery_id)
+    if gallery is None:
+        raise HTTPException(status_code=404, detail="Gallery not found")
+    return [GalleryAssetRead.model_validate(asset) for asset in gallery.assets]
+
+
+@app.post("/api/studio/render", response_model=StudioRenderResponse)
+def render_studio_video(payload: StudioRenderRequest, db=Depends(get_db)):
+    assets = (
+        db.query(GalleryAsset)
+        .filter(GalleryAsset.id.in_(payload.asset_ids))
+        .order_by(GalleryAsset.created_at.asc())
+        .all()
+    )
+    if len(assets) != len(payload.asset_ids):
+        raise HTTPException(status_code=404, detail="One or more assets were not found")
+
+    storyboard_prompt = " \n".join(
+        f"Scene {index + 1}: {asset.title}" for index, asset in enumerate(assets)
+    )
+    video_info = openai_client.create_video(
+        prompt=f"Compose a {payload.orientation} video with scenes: {storyboard_prompt}",
+        aspect_ratio="9:16" if payload.orientation == "vertical" else "16:9",
+        duration_seconds=min(12, 4 * len(assets)),
+        quality="high",
+    )
+
+    asset = GalleryAsset(
+        asset_type="video",
+        title=payload.title[:80] if payload.title else "Studio montage",
+        description=payload.description
+        or f"Studio composition ({payload.orientation}) crafted from {len(assets)} assets.",
+        url=video_info["url"],
+        metadata_json=json.dumps(
+            {
+                "revised_prompt": video_info.get("revised_prompt"),
+                "source_asset_ids": payload.asset_ids,
+                "orientation": payload.orientation,
+                "thumbnail_url": video_info.get("thumbnail_url"),
+            }
+        ),
+    )
+    db.add(asset)
+    db.flush()
+    db.refresh(asset)
+
+    return StudioRenderResponse(asset=GalleryAssetRead.model_validate(asset))

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -2,9 +2,10 @@
 from __future__ import annotations
 
 from datetime import datetime
+import json
 from typing import Any, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class ConversationCreate(BaseModel):
@@ -54,10 +55,57 @@ class GalleryAssetRead(BaseModel):
     description: Optional[str]
     url: str
     metadata_json: Optional[str]
+    metadata: Optional[dict[str, Any]] = None
+    gallery_ids: list[int] = Field(default_factory=list)
     created_at: datetime
 
     class Config:
         from_attributes = True
+
+    @model_validator(mode="after")
+    def _populate_metadata(self) -> "GalleryAssetRead":
+        if self.metadata is None and self.metadata_json:
+            try:
+                self.metadata = json.loads(self.metadata_json)
+            except ValueError:
+                self.metadata = None
+        return self
+
+
+class GalleryCreate(BaseModel):
+    name: str
+    description: Optional[str] = None
+    category: Optional[str] = None
+    accent_color: Optional[str] = Field(default="#10a37f")
+    layout: Optional[str] = Field(default="grid")
+
+
+class GalleryUpdate(BaseModel):
+    name: Optional[str] = None
+    description: Optional[str] = None
+    category: Optional[str] = None
+    accent_color: Optional[str] = None
+    layout: Optional[str] = None
+
+
+class GalleryRead(BaseModel):
+    id: int
+    name: str
+    description: Optional[str]
+    category: Optional[str]
+    accent_color: Optional[str]
+    layout: Optional[str]
+    asset_count: int = Field(default=0)
+    created_at: datetime
+    updated_at: datetime
+    assets: list[GalleryAssetRead] = Field(default_factory=list)
+
+    class Config:
+        from_attributes = True
+
+
+class GalleryAssetAssignment(BaseModel):
+    asset_id: int
 
 
 class OpenAIResponse(BaseModel):
@@ -70,7 +118,30 @@ class ImageRequest(BaseModel):
     prompt: str
     size: str = Field(default="1024x1024")
     quality: str = Field(default="high")
+    aspect_ratio: str = Field(default="1:1")
 
 
 class ImageResponse(BaseModel):
+    asset: GalleryAssetRead
+
+
+class VideoRequest(BaseModel):
+    prompt: str
+    aspect_ratio: str = Field(default="16:9")
+    duration_seconds: int = Field(default=8, ge=1, le=120)
+    quality: str = Field(default="high")
+
+
+class VideoResponse(BaseModel):
+    asset: GalleryAssetRead
+
+
+class StudioRenderRequest(BaseModel):
+    title: str
+    orientation: str = Field(pattern=r"^(vertical|landscape)$")
+    asset_ids: list[int] = Field(min_length=1)
+    description: Optional[str] = None
+
+
+class StudioRenderResponse(BaseModel):
     asset: GalleryAssetRead

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -2,6 +2,18 @@ const state = {
   conversations: [],
   currentConversationId: null,
   messages: {},
+  assets: [],
+  galleries: [],
+  filters: {
+    feedSearch: '',
+    feedType: 'all',
+    gallerySearch: '',
+    galleryCategory: 'all',
+  },
+  composer: {
+    selectedAssets: [],
+    source: 'feed',
+  },
 };
 
 const conversationListEl = document.getElementById('conversation-list');
@@ -10,11 +22,41 @@ const chatFormEl = document.getElementById('chat-form');
 const chatInputEl = document.getElementById('chat-input');
 const modelSelectEl = document.getElementById('model-select');
 const newConversationBtn = document.getElementById('new-conversation');
-const imageFormEl = document.getElementById('image-form');
-const imagePromptEl = document.getElementById('image-prompt');
-const imageSizeEl = document.getElementById('image-size');
-const imageQualityEl = document.getElementById('image-quality');
 const galleryEl = document.getElementById('gallery');
+const feedSearchEl = document.getElementById('feed-search');
+const feedTypeFilterEl = document.getElementById('feed-type-filter');
+
+const studioEl = document.getElementById('studio');
+const studioToggleBtn = document.getElementById('studio-toggle');
+const studioCloseBtn = document.getElementById('studio-close');
+const studioNavButtons = Array.from(document.querySelectorAll('.studio__nav-btn'));
+const studioGenerateForm = document.getElementById('studio-generate-form');
+const studioPromptEl = document.getElementById('studio-prompt');
+const studioAssetTypeEl = document.getElementById('studio-asset-type');
+const studioSizeEl = document.getElementById('studio-size');
+const studioAspectEl = document.getElementById('studio-aspect');
+const studioQualityEl = document.getElementById('studio-quality');
+const studioDurationEl = document.getElementById('studio-duration');
+const studioDurationField = document.getElementById('studio-duration-field');
+
+const studioGalleryForm = document.getElementById('studio-gallery-form');
+const studioGalleryNameEl = document.getElementById('studio-gallery-name');
+const studioGalleryCategoryEl = document.getElementById('studio-gallery-category');
+const studioGalleryColorEl = document.getElementById('studio-gallery-color');
+const studioGalleryLayoutEl = document.getElementById('studio-gallery-layout');
+const studioGalleryDescriptionEl = document.getElementById('studio-gallery-description');
+const studioGallerySearchEl = document.getElementById('studio-gallery-search');
+const studioGalleryFilterEl = document.getElementById('studio-gallery-filter');
+const studioGalleryListEl = document.getElementById('studio-gallery-list');
+
+const composerGallerySelectEl = document.getElementById('composer-gallery-select');
+const composerLibraryEl = document.getElementById('composer-library');
+const composerTimelineEl = document.getElementById('composer-timeline');
+const composerRenderBtn = document.getElementById('composer-render');
+const composerClearBtn = document.getElementById('composer-clear');
+const composerTitleEl = document.getElementById('composer-title');
+const composerOrientationEl = document.getElementById('composer-orientation');
+const composerDescriptionEl = document.getElementById('composer-description');
 
 async function fetchJSON(url, options) {
   const res = await fetch(url, {
@@ -124,57 +166,649 @@ async function sendMessage(event) {
   }
 }
 
-async function loadGallery() {
-  const assets = await fetchJSON('/api/gallery');
+function filterAssets() {
+  const search = state.filters.feedSearch.toLowerCase();
+  const type = state.filters.feedType;
+  return state.assets.filter((asset) => {
+    const searchable = `${asset.title || ''} ${asset.description || ''}`.toLowerCase();
+    const matchesSearch = !search || searchable.includes(search);
+    const matchesType = type === 'all' || asset.asset_type === type;
+    return matchesSearch && matchesType;
+  });
+}
+
+function renderGallery() {
+  const assets = filterAssets();
   galleryEl.innerHTML = '';
+  if (!assets.length) {
+    const empty = document.createElement('p');
+    empty.className = 'gallery-card__meta';
+    empty.textContent = 'No assets yet. Use the Studio to generate new visuals.';
+    galleryEl.appendChild(empty);
+    return;
+  }
+
   assets.forEach((asset) => {
     const card = document.createElement('article');
     card.className = 'gallery-card';
-    const img = document.createElement('img');
-    img.src = asset.url;
-    img.alt = asset.title;
+
+    const mediaWrapper = document.createElement(asset.asset_type === 'video' ? 'video' : 'img');
+    const thumbnail = asset.metadata?.thumbnail_url;
+    mediaWrapper.src = asset.asset_type === 'video' ? asset.url : asset.url;
+    if (asset.asset_type === 'video') {
+      mediaWrapper.controls = true;
+      mediaWrapper.muted = true;
+      mediaWrapper.loop = true;
+      mediaWrapper.playsInline = true;
+      mediaWrapper.setAttribute('playsinline', '');
+      if (thumbnail) {
+        mediaWrapper.poster = thumbnail;
+      }
+    } else {
+      mediaWrapper.alt = asset.title;
+    }
+    card.appendChild(mediaWrapper);
+
     const content = document.createElement('div');
     content.className = 'gallery-card__content';
+
     const title = document.createElement('h3');
     title.className = 'gallery-card__title';
-    title.textContent = asset.title;
+    title.textContent = asset.title || 'Untitled asset';
+
     const meta = document.createElement('p');
     meta.className = 'gallery-card__meta';
     meta.textContent = asset.description || 'Generated asset';
 
+    const actions = document.createElement('div');
+    actions.className = 'gallery-card__actions';
+
+    const gallerySelect = document.createElement('select');
+    const defaultOption = document.createElement('option');
+    defaultOption.value = '';
+    defaultOption.textContent = 'Add to gallery…';
+    gallerySelect.appendChild(defaultOption);
+    state.galleries.forEach((gallery) => {
+      const option = document.createElement('option');
+      option.value = String(gallery.id);
+      option.textContent = gallery.name;
+      gallerySelect.appendChild(option);
+    });
+
+    const addButton = document.createElement('button');
+    addButton.className = 'btn';
+    addButton.type = 'button';
+    addButton.textContent = 'Add';
+    addButton.addEventListener('click', async () => {
+      const galleryId = Number(gallerySelect.value);
+      if (!galleryId) return;
+      addButton.disabled = true;
+      addButton.textContent = 'Adding…';
+      try {
+        await fetchJSON(`/api/galleries/${galleryId}/assets`, {
+          method: 'POST',
+          body: JSON.stringify({ asset_id: asset.id }),
+        });
+        await loadGalleries();
+        addButton.textContent = 'Added';
+      } catch (error) {
+        console.error(error);
+        alert('Unable to add asset to gallery.');
+        addButton.textContent = 'Add';
+      } finally {
+        addButton.disabled = false;
+        gallerySelect.value = '';
+        setTimeout(() => {
+          addButton.textContent = 'Add';
+        }, 1500);
+      }
+    });
+
+    actions.appendChild(gallerySelect);
+    actions.appendChild(addButton);
+
     content.appendChild(title);
     content.appendChild(meta);
-    card.appendChild(img);
+    if (state.galleries.length) {
+      content.appendChild(actions);
+    }
     card.appendChild(content);
     galleryEl.appendChild(card);
   });
 }
 
-async function generateImage(event) {
+async function loadGallery() {
+  const assets = await fetchJSON('/api/gallery');
+  state.assets = assets;
+  syncComposerSelection();
+  renderGallery();
+  renderComposerLibrary();
+  renderComposerTimeline();
+}
+
+function toggleStudio(open) {
+  const isOpen = open ?? !studioEl.classList.contains('is-open');
+  if (isOpen) {
+    studioEl.classList.add('is-open');
+    studioEl.setAttribute('aria-hidden', 'false');
+  } else {
+    studioEl.classList.remove('is-open');
+    studioEl.setAttribute('aria-hidden', 'true');
+  }
+}
+
+function setStudioView(view) {
+  studioNavButtons.forEach((button) => {
+    const isMatch = button.dataset.view === view;
+    button.classList.toggle('is-active', isMatch);
+    const target = document.querySelector(`.studio-view[data-view="${button.dataset.view}"]`);
+    if (target) {
+      target.classList.toggle('is-active', target.dataset.view === view);
+    }
+  });
+}
+
+function syncDurationVisibility() {
+  const type = studioAssetTypeEl.value;
+  studioDurationField.style.display = type === 'video' ? 'block' : 'none';
+}
+
+async function handleGenerateAsset(event) {
   event.preventDefault();
-  const prompt = imagePromptEl.value.trim();
+  const prompt = studioPromptEl.value.trim();
   if (!prompt) return;
+  const type = studioAssetTypeEl.value;
   try {
-    const response = await fetchJSON('/api/images', {
-      method: 'POST',
-      body: JSON.stringify({
-        prompt,
-        size: imageSizeEl.value,
-        quality: imageQualityEl.value.toLowerCase(),
-      }),
-    });
-    imagePromptEl.value = '';
-    state.gallery = state.gallery || [];
+    if (type === 'video') {
+      await fetchJSON('/api/videos', {
+        method: 'POST',
+        body: JSON.stringify({
+          prompt,
+          aspect_ratio: studioAspectEl.value,
+          duration_seconds: Number(studioDurationEl.value) || 8,
+          quality: studioQualityEl.value,
+        }),
+      });
+    } else {
+      await fetchJSON('/api/images', {
+        method: 'POST',
+        body: JSON.stringify({
+          prompt,
+          size: studioSizeEl.value,
+          quality: studioQualityEl.value,
+          aspect_ratio: studioAspectEl.value,
+        }),
+      });
+    }
+    studioGenerateForm.reset();
+    studioAssetTypeEl.value = 'image';
+    studioSizeEl.value = '1024x1024';
+    studioAspectEl.value = '1:1';
+    studioQualityEl.value = 'high';
+    studioDurationEl.value = 8;
+    syncDurationVisibility();
     await loadGallery();
+    await loadGalleries();
   } catch (error) {
     console.error(error);
-    alert('Image generation failed. Ensure your API key is configured.');
+    alert('Generation failed. Ensure your API key is configured.');
   }
+}
+
+async function loadGalleries() {
+  const galleries = await fetchJSON('/api/galleries');
+  state.galleries = galleries;
+  syncComposerSelection();
+  populateGalleryFilter();
+  renderGallery();
+  renderStudioGalleries();
+  renderComposerLibrary();
+  populateComposerSources();
+}
+
+function populateGalleryFilter() {
+  const categories = new Set(['all']);
+  state.galleries.forEach((gallery) => {
+    if (gallery.category) categories.add(gallery.category.toLowerCase());
+  });
+  const previousValue = state.filters.galleryCategory;
+  studioGalleryFilterEl.innerHTML = '';
+  categories.forEach((category) => {
+    const option = document.createElement('option');
+    option.value = category;
+    option.textContent = category === 'all' ? 'All categories' : category;
+    studioGalleryFilterEl.appendChild(option);
+  });
+  if (categories.has(previousValue)) {
+    studioGalleryFilterEl.value = previousValue;
+  } else {
+    studioGalleryFilterEl.value = 'all';
+    state.filters.galleryCategory = 'all';
+  }
+}
+
+function populateComposerSources() {
+  const existingValue = composerGallerySelectEl.value;
+  composerGallerySelectEl.innerHTML = '';
+  const feedOption = document.createElement('option');
+  feedOption.value = 'feed';
+  feedOption.textContent = 'Main feed';
+  composerGallerySelectEl.appendChild(feedOption);
+  state.galleries.forEach((gallery) => {
+    const option = document.createElement('option');
+    option.value = String(gallery.id);
+    option.textContent = gallery.name;
+    composerGallerySelectEl.appendChild(option);
+  });
+  if (
+    existingValue &&
+    (existingValue === 'feed' || state.galleries.some((gallery) => String(gallery.id) === existingValue))
+  ) {
+    composerGallerySelectEl.value = existingValue;
+    state.composer.source = existingValue;
+  } else {
+    composerGallerySelectEl.value = 'feed';
+    state.composer.source = 'feed';
+  }
+}
+
+function renderStudioGalleries() {
+  const search = state.filters.gallerySearch.toLowerCase();
+  const category = state.filters.galleryCategory;
+  studioGalleryListEl.innerHTML = '';
+  const filtered = state.galleries.filter((gallery) => {
+    const matchesSearch =
+      !search ||
+      gallery.name.toLowerCase().includes(search) ||
+      (gallery.description || '').toLowerCase().includes(search);
+    const matchesCategory =
+      category === 'all' || (gallery.category || '').toLowerCase() === category;
+    return matchesSearch && matchesCategory;
+  });
+
+  if (!filtered.length) {
+    const empty = document.createElement('p');
+    empty.className = 'studio-gallery-card__meta';
+    empty.textContent = 'No galleries yet. Create one to curate your campaigns.';
+    studioGalleryListEl.appendChild(empty);
+    return;
+  }
+
+  filtered.forEach((gallery) => {
+    const card = document.createElement('article');
+    card.className = 'studio-gallery-card';
+
+    const header = document.createElement('div');
+    header.style.display = 'flex';
+    header.style.alignItems = 'center';
+    header.style.justifyContent = 'space-between';
+    header.style.gap = '0.75rem';
+
+    const title = document.createElement('h4');
+    title.textContent = gallery.name;
+    title.style.margin = '0';
+
+    const swatch = document.createElement('span');
+    swatch.className = 'studio-gallery-card__swatch';
+    if (gallery.accent_color) {
+      swatch.style.background = gallery.accent_color;
+    }
+    header.appendChild(title);
+    header.appendChild(swatch);
+
+    const chip = document.createElement('span');
+    chip.className = 'studio-gallery-card__chip';
+    chip.textContent = (gallery.category || 'Uncategorised').toUpperCase();
+    if (gallery.accent_color) {
+      chip.style.background = `${gallery.accent_color}33`;
+      chip.style.color = gallery.accent_color;
+    }
+
+    const description = document.createElement('p');
+    description.className = 'studio-gallery-card__meta';
+    description.textContent =
+      gallery.description || 'Fully editable and ready to showcase your creative direction.';
+
+    const stats = document.createElement('p');
+    stats.className = 'studio-gallery-card__meta';
+    stats.textContent = `Assets: ${gallery.asset_count} • Layout: ${gallery.layout || 'grid'}`;
+
+    const actions = document.createElement('div');
+    actions.className = 'studio-gallery-card__actions';
+
+    const colorInput = document.createElement('input');
+    colorInput.type = 'color';
+    colorInput.value = gallery.accent_color || '#10a37f';
+    colorInput.addEventListener('input', async (event) => {
+      try {
+        await fetchJSON(`/api/galleries/${gallery.id}`, {
+          method: 'PATCH',
+          body: JSON.stringify({ accent_color: event.target.value }),
+        });
+        await loadGalleries();
+      } catch (error) {
+        console.error(error);
+        alert('Unable to update accent color.');
+      }
+    });
+
+    const layoutSelect = document.createElement('select');
+    ['grid', 'masonry', 'filmstrip'].forEach((layout) => {
+      const option = document.createElement('option');
+      option.value = layout;
+      option.textContent = layout.charAt(0).toUpperCase() + layout.slice(1);
+      layoutSelect.appendChild(option);
+    });
+    layoutSelect.value = gallery.layout || 'grid';
+    layoutSelect.addEventListener('change', async (event) => {
+      try {
+        await fetchJSON(`/api/galleries/${gallery.id}`, {
+          method: 'PATCH',
+          body: JSON.stringify({ layout: event.target.value }),
+        });
+        await loadGalleries();
+      } catch (error) {
+        console.error(error);
+        alert('Unable to update layout.');
+      }
+    });
+
+    const renameButton = document.createElement('button');
+    renameButton.type = 'button';
+    renameButton.textContent = 'Edit details';
+    renameButton.addEventListener('click', async () => {
+      const name = prompt('Gallery name', gallery.name) || gallery.name;
+      const descriptionValue = prompt('Gallery description', gallery.description || '') || gallery.description;
+      const categoryValue = prompt('Gallery category', gallery.category || '') || gallery.category;
+      try {
+        await fetchJSON(`/api/galleries/${gallery.id}`, {
+          method: 'PATCH',
+          body: JSON.stringify({
+            name,
+            description: descriptionValue,
+            category: categoryValue,
+          }),
+        });
+        await loadGalleries();
+      } catch (error) {
+        console.error(error);
+        alert('Unable to update gallery.');
+      }
+    });
+
+    actions.appendChild(colorInput);
+    actions.appendChild(layoutSelect);
+    actions.appendChild(renameButton);
+
+    card.appendChild(header);
+    card.appendChild(chip);
+    card.appendChild(description);
+    card.appendChild(stats);
+    card.appendChild(actions);
+    studioGalleryListEl.appendChild(card);
+  });
+}
+
+function getComposerSourceAssets() {
+  if (state.composer.source === 'feed') {
+    return state.assets;
+  }
+  const gallery = state.galleries.find((item) => String(item.id) === state.composer.source);
+  return gallery ? gallery.assets : [];
+}
+
+function renderComposerLibrary() {
+  if (!composerLibraryEl) return;
+  const assets = getComposerSourceAssets();
+  composerLibraryEl.innerHTML = '';
+  assets.forEach((asset) => {
+    const tile = document.createElement('div');
+    tile.className = 'studio-composer__tile';
+    if (state.composer.selectedAssets.some((item) => item.id === asset.id)) {
+      tile.classList.add('is-selected');
+    }
+    const media = document.createElement(asset.asset_type === 'video' ? 'video' : 'img');
+    if (asset.asset_type === 'video') {
+      media.src = asset.url;
+      media.muted = true;
+      media.loop = true;
+      media.playsInline = true;
+      media.setAttribute('playsinline', '');
+      if (asset.metadata?.thumbnail_url) {
+        media.poster = asset.metadata.thumbnail_url;
+      }
+    } else {
+      media.src = asset.url;
+    }
+    tile.appendChild(media);
+
+    const caption = document.createElement('span');
+    caption.textContent = asset.title || 'Untitled';
+    tile.appendChild(caption);
+
+    tile.addEventListener('click', () => {
+      const alreadySelected = state.composer.selectedAssets.some((item) => item.id === asset.id);
+      if (alreadySelected) {
+        state.composer.selectedAssets = state.composer.selectedAssets.filter(
+          (item) => item.id !== asset.id,
+        );
+      } else {
+        state.composer.selectedAssets = [...state.composer.selectedAssets, asset];
+      }
+      renderComposerLibrary();
+      renderComposerTimeline();
+    });
+
+    composerLibraryEl.appendChild(tile);
+  });
+}
+
+function moveComposerAsset(index, direction) {
+  const newIndex = index + direction;
+  if (newIndex < 0 || newIndex >= state.composer.selectedAssets.length) return;
+  const updated = [...state.composer.selectedAssets];
+  const [removed] = updated.splice(index, 1);
+  updated.splice(newIndex, 0, removed);
+  state.composer.selectedAssets = updated;
+  renderComposerTimeline();
+}
+
+function renderComposerTimeline() {
+  if (!composerTimelineEl) return;
+  composerTimelineEl.innerHTML = '';
+  if (!state.composer.selectedAssets.length) {
+    const empty = document.createElement('li');
+    empty.className = 'studio-gallery-card__meta';
+    empty.textContent = 'Select imagery or clips to build your montage.';
+    composerTimelineEl.appendChild(empty);
+    composerRenderBtn.disabled = true;
+    return;
+  }
+
+  state.composer.selectedAssets.forEach((asset, index) => {
+    const item = document.createElement('li');
+    item.className = 'studio-composer__timeline-item';
+
+    const thumb = document.createElement('div');
+    thumb.className = 'timeline-thumb';
+    const thumbMedia = document.createElement(asset.asset_type === 'video' ? 'video' : 'img');
+    if (asset.asset_type === 'video') {
+      thumbMedia.src = asset.url;
+      thumbMedia.muted = true;
+      thumbMedia.playsInline = true;
+      thumbMedia.setAttribute('playsinline', '');
+      if (asset.metadata?.thumbnail_url) {
+        thumbMedia.poster = asset.metadata.thumbnail_url;
+      }
+    } else {
+      thumbMedia.src = asset.url;
+    }
+    thumb.appendChild(thumbMedia);
+
+    const label = document.createElement('span');
+    label.textContent = `${index + 1}. ${asset.title}`;
+
+    const upButton = document.createElement('button');
+    upButton.type = 'button';
+    upButton.textContent = '▲';
+    upButton.addEventListener('click', () => moveComposerAsset(index, -1));
+
+    const downButton = document.createElement('button');
+    downButton.type = 'button';
+    downButton.textContent = '▼';
+    downButton.addEventListener('click', () => moveComposerAsset(index, 1));
+
+    const removeButton = document.createElement('button');
+    removeButton.type = 'button';
+    removeButton.textContent = 'Remove';
+    removeButton.addEventListener('click', () => {
+      state.composer.selectedAssets = state.composer.selectedAssets.filter((item) => item.id !== asset.id);
+      renderComposerTimeline();
+      renderComposerLibrary();
+    });
+
+    item.appendChild(thumb);
+    item.appendChild(label);
+    item.appendChild(upButton);
+    item.appendChild(downButton);
+    item.appendChild(removeButton);
+    composerTimelineEl.appendChild(item);
+  });
+
+  composerRenderBtn.disabled = false;
+}
+
+function syncComposerSelection() {
+  const assetMap = new Map();
+  state.assets.forEach((asset) => assetMap.set(asset.id, asset));
+  state.galleries.forEach((gallery) => {
+    (gallery.assets || []).forEach((asset) => assetMap.set(asset.id, asset));
+  });
+  state.composer.selectedAssets = state.composer.selectedAssets
+    .map((asset) => assetMap.get(asset.id) || asset)
+    .filter((asset) => Boolean(assetMap.get(asset.id)));
+}
+
+async function handleCreateGallery(event) {
+  event.preventDefault();
+  const name = studioGalleryNameEl.value.trim();
+  if (!name) return;
+  try {
+    await fetchJSON('/api/galleries', {
+      method: 'POST',
+      body: JSON.stringify({
+        name,
+        category: studioGalleryCategoryEl.value.trim() || null,
+        accent_color: studioGalleryColorEl.value,
+        layout: studioGalleryLayoutEl.value,
+        description: studioGalleryDescriptionEl.value.trim() || null,
+      }),
+    });
+    studioGalleryForm.reset();
+    studioGalleryColorEl.value = '#10a37f';
+    studioGalleryLayoutEl.value = 'grid';
+    await loadGalleries();
+  } catch (error) {
+    console.error(error);
+    alert('Unable to create gallery.');
+  }
+}
+
+async function handleComposerRender() {
+  if (!state.composer.selectedAssets.length) return;
+  composerRenderBtn.disabled = true;
+  composerRenderBtn.textContent = 'Rendering…';
+  try {
+    await fetchJSON('/api/studio/render', {
+      method: 'POST',
+      body: JSON.stringify({
+        title: composerTitleEl.value || 'Studio montage',
+        orientation: composerOrientationEl.value,
+        asset_ids: state.composer.selectedAssets.map((asset) => asset.id),
+        description: composerDescriptionEl.value || undefined,
+      }),
+    });
+    state.composer.selectedAssets = [];
+    composerTitleEl.value = '';
+    composerDescriptionEl.value = '';
+    await loadGallery();
+    await loadGalleries();
+  } catch (error) {
+    console.error(error);
+    alert('Unable to render video.');
+  } finally {
+    composerRenderBtn.disabled = false;
+    composerRenderBtn.textContent = 'Render final video';
+    renderComposerTimeline();
+    renderComposerLibrary();
+  }
+}
+
+function handleComposerSourceChange(event) {
+  state.composer.source = event.target.value;
+  renderComposerLibrary();
+}
+
+function handleFeedSearch(event) {
+  state.filters.feedSearch = event.target.value;
+  renderGallery();
+}
+
+function handleFeedTypeChange(event) {
+  state.filters.feedType = event.target.value;
+  renderGallery();
+}
+
+function handleGallerySearch(event) {
+  state.filters.gallerySearch = event.target.value;
+  renderStudioGalleries();
+}
+
+function handleGalleryFilter(event) {
+  state.filters.galleryCategory = event.target.value;
+  renderStudioGalleries();
+}
+
+function initialiseStudioNavigation() {
+  studioNavButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      setStudioView(button.dataset.view);
+    });
+  });
+  setStudioView('generate');
 }
 
 newConversationBtn.addEventListener('click', createConversation);
 chatFormEl.addEventListener('submit', sendMessage);
-imageFormEl.addEventListener('submit', generateImage);
+feedSearchEl.addEventListener('input', handleFeedSearch);
+feedTypeFilterEl.addEventListener('change', handleFeedTypeChange);
+studioToggleBtn.addEventListener('click', () => toggleStudio(true));
+studioCloseBtn.addEventListener('click', () => toggleStudio(false));
+studioGenerateForm.addEventListener('submit', handleGenerateAsset);
+studioAssetTypeEl.addEventListener('change', () => {
+  syncDurationVisibility();
+});
+studioGalleryForm.addEventListener('submit', handleCreateGallery);
+studioGallerySearchEl.addEventListener('input', handleGallerySearch);
+studioGalleryFilterEl.addEventListener('change', handleGalleryFilter);
+composerGallerySelectEl.addEventListener('change', (event) => {
+  handleComposerSourceChange(event);
+});
+composerRenderBtn.addEventListener('click', handleComposerRender);
+composerClearBtn.addEventListener('click', () => {
+  state.composer.selectedAssets = [];
+  renderComposerTimeline();
+  renderComposerLibrary();
+});
 
+document.addEventListener('keydown', (event) => {
+  if (event.key === 'Escape' && studioEl.classList.contains('is-open')) {
+    toggleStudio(false);
+  }
+});
+
+initialiseStudioNavigation();
+syncDurationVisibility();
 loadConversations();
 loadGallery();
+loadGalleries();

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -19,6 +19,41 @@ body {
   min-height: 100vh;
 }
 
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem clamp(1.5rem, 4vw, 4rem);
+  backdrop-filter: blur(18px);
+  background: linear-gradient(90deg, rgba(11, 13, 18, 0.85), rgba(11, 13, 18, 0.55));
+  border-bottom: 1px solid var(--border);
+}
+
+.topbar__brand {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.topbar__logo {
+  display: grid;
+  place-items: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 0.75rem;
+  background: rgba(16, 163, 127, 0.18);
+}
+
+.topbar__actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
 .hero {
   padding: 3rem clamp(2rem, 6vw, 6rem);
   display: flex;
@@ -76,6 +111,29 @@ body {
   font-size: 1.3rem;
 }
 
+.panel__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.feed-controls {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.feed-controls input,
+.feed-controls select {
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: rgba(15, 23, 42, 0.65);
+  padding: 0.6rem 1rem;
+  color: var(--text);
+}
+
 .btn {
   cursor: pointer;
   border: 1px solid var(--border);
@@ -100,6 +158,16 @@ body {
 
 .btn--primary:hover {
   filter: brightness(1.05);
+}
+
+.btn--ghost {
+  background: rgba(15, 23, 42, 0.35);
+  border-color: rgba(148, 163, 184, 0.3);
+}
+
+.btn--ghost:hover {
+  border-color: var(--accent);
+  color: var(--accent);
 }
 
 .conversation-list {
@@ -182,9 +250,7 @@ body {
   gap: 1rem;
 }
 
-.chat-form select,
-.image-form select,
-.image-form input {
+.chat-form select {
   border-radius: 999px;
   border: 1px solid var(--border);
   background: rgba(15, 23, 42, 0.65);
@@ -193,22 +259,9 @@ body {
   font-weight: 500;
 }
 
-.image-form {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-  margin-bottom: 1.5rem;
-}
-
-.image-form__controls {
-  display: flex;
-  gap: 0.5rem;
-  flex-wrap: wrap;
-}
-
 .gallery {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   gap: 1rem;
 }
 
@@ -219,6 +272,7 @@ body {
   background: rgba(15, 23, 42, 0.65);
   display: flex;
   flex-direction: column;
+  position: relative;
 }
 
 .gallery-card img {
@@ -227,8 +281,17 @@ body {
   object-fit: cover;
 }
 
+.gallery-card video {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  object-fit: cover;
+  background: rgba(15, 23, 42, 0.85);
+}
+
 .gallery-card__content {
   padding: 0.75rem 1rem 1rem;
+  display: grid;
+  gap: 0.4rem;
 }
 
 .gallery-card__title {
@@ -241,11 +304,405 @@ body {
   font-size: 0.85rem;
 }
 
+.gallery-card__actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.gallery-card__actions select {
+  flex: 1 1 140px;
+  border-radius: 0.75rem;
+  border: 1px solid var(--border);
+  background: rgba(15, 23, 42, 0.65);
+  padding: 0.45rem 0.75rem;
+  color: var(--text);
+}
+
+.gallery-card__actions button {
+  flex: 0 0 auto;
+}
+
+.studio {
+  position: fixed;
+  inset: 0;
+  background: rgba(4, 8, 14, 0.65);
+  backdrop-filter: blur(12px);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 4vh 3vw;
+  z-index: 30;
+}
+
+.studio.is-open {
+  display: flex;
+}
+
+.studio__surface {
+  width: min(1200px, 95vw);
+  height: min(90vh, 860px);
+  background: rgba(7, 11, 19, 0.95);
+  border: 1px solid rgba(59, 130, 246, 0.2);
+  border-radius: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  box-shadow: 0 28px 60px rgba(2, 8, 20, 0.45);
+}
+
+.studio__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem 2rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.85), rgba(30, 41, 59, 0.65));
+}
+
+.studio__eyebrow {
+  letter-spacing: 0.25em;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin: 0 0 0.35rem;
+}
+
+.studio__header h2 {
+  margin: 0;
+}
+
+.studio__body {
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  flex: 1;
+  overflow: hidden;
+}
+
+.studio__sidebar {
+  border-right: 1px solid rgba(148, 163, 184, 0.15);
+  padding: 1.5rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  background: rgba(9, 13, 23, 0.85);
+}
+
+.studio__nav-btn {
+  border-radius: 1rem;
+  border: 1px solid transparent;
+  padding: 0.75rem 1rem;
+  text-align: left;
+  background: transparent;
+  color: var(--muted);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.studio__nav-btn:hover,
+.studio__nav-btn.is-active {
+  background: rgba(16, 163, 127, 0.15);
+  border-color: rgba(16, 163, 127, 0.45);
+  color: var(--text);
+}
+
+.studio__workspace {
+  padding: 2rem;
+  overflow-y: auto;
+}
+
+.studio-view {
+  display: none;
+  animation: fade-in 0.25s ease;
+}
+
+.studio-view.is-active {
+  display: block;
+}
+
+.studio-view__header h3 {
+  margin: 0 0 0.35rem;
+}
+
+.studio-view__header p {
+  margin: 0 0 1.5rem;
+  color: var(--muted);
+}
+
+.studio-form {
+  display: grid;
+  gap: 1.25rem;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  border-radius: 1.5rem;
+  padding: 1.75rem;
+}
+
+.studio-form--inline {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  align-items: end;
+}
+
+.studio-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  font-size: 0.95rem;
+}
+
+.studio-field span {
+  color: var(--muted);
+  font-size: 0.8rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.studio-field input,
+.studio-field select,
+.studio-field textarea {
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(7, 11, 19, 0.85);
+  color: var(--text);
+  padding: 0.75rem 1rem;
+  font: inherit;
+}
+
+.studio-field textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+.studio-field--wide {
+  grid-column: 1 / -1;
+}
+
+.studio-form__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.studio-form__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1rem;
+}
+
+.studio-form__hint {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.studio-gallery__controls {
+  margin: 1.5rem 0;
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.studio-gallery__controls input,
+.studio-gallery__controls select {
+  border-radius: 0.9rem;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(7, 11, 19, 0.8);
+  color: var(--text);
+  padding: 0.65rem 1rem;
+}
+
+.studio-gallery__list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.25rem;
+}
+
+.studio-gallery-card {
+  border-radius: 1.25rem;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(9, 13, 23, 0.85);
+  padding: 1.5rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.studio-gallery-card__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: rgba(16, 163, 127, 0.2);
+}
+
+.studio-gallery-card__meta {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.studio-gallery-card__actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.studio-gallery-card__actions button,
+.studio-gallery-card__actions select {
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.65);
+  color: var(--text);
+  padding: 0.5rem 0.75rem;
+}
+
+.studio-gallery-card__swatch {
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.studio-composer {
+  margin-top: 2rem;
+  display: grid;
+  grid-template-columns: minmax(280px, 1fr) minmax(300px, 0.9fr);
+  gap: 1.5rem;
+}
+
+.studio-composer__library,
+.studio-composer__timeline {
+  background: rgba(9, 13, 23, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 1.25rem;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.studio-composer__library-header,
+.studio-composer__timeline-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.studio-composer__library-header select {
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.65);
+  color: var(--text);
+  padding: 0.5rem 0.75rem;
+}
+
+.studio-composer__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 0.75rem;
+}
+
+.studio-composer__tile {
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  overflow: hidden;
+  background: rgba(15, 23, 42, 0.65);
+  cursor: pointer;
+  position: relative;
+}
+
+.studio-composer__tile img,
+.studio-composer__tile video {
+  width: 100%;
+  display: block;
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
+}
+
+.studio-composer__tile span {
+  position: absolute;
+  inset: auto 0 0 0;
+  padding: 0.35rem 0.5rem;
+  font-size: 0.75rem;
+  background: linear-gradient(180deg, transparent, rgba(4, 7, 15, 0.9));
+}
+
+.studio-composer__tile:hover,
+.studio-composer__tile.is-selected {
+  border-color: rgba(16, 163, 127, 0.65);
+  box-shadow: 0 0 0 2px rgba(16, 163, 127, 0.2);
+}
+
+.studio-composer__timeline-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.studio-composer__timeline-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 1rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.studio-composer__timeline-item button {
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(7, 11, 19, 0.85);
+  color: var(--text);
+  padding: 0.35rem 0.65rem;
+}
+
+.studio-composer__timeline-item .timeline-thumb {
+  width: 60px;
+  height: 40px;
+  border-radius: 0.6rem;
+  overflow: hidden;
+  background: rgba(4, 7, 15, 0.85);
+  display: grid;
+  place-items: center;
+}
+
+.studio-composer__timeline-item .timeline-thumb img,
+.studio-composer__timeline-item .timeline-thumb video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
 .footer {
   padding: 2rem;
   text-align: center;
   color: var(--muted);
   font-size: 0.9rem;
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 900px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (max-width: 768px) {
@@ -254,7 +711,27 @@ body {
     align-items: stretch;
   }
 
-  .image-form__controls {
+  .feed-controls {
     flex-direction: column;
+    align-items: stretch;
+  }
+
+  .studio__body {
+    grid-template-columns: 1fr;
+  }
+
+  .studio__sidebar {
+    flex-direction: row;
+    justify-content: space-between;
+    border-right: none;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.15);
+  }
+
+  .studio__workspace {
+    padding: 1.5rem;
+  }
+
+  .studio-composer {
+    grid-template-columns: 1fr;
   }
 }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -8,12 +8,24 @@
     <link rel="stylesheet" href="/static/style.css" />
   </head>
   <body>
+    <header class="topbar">
+      <div class="topbar__brand">
+        <span class="topbar__logo" aria-hidden="true">✨</span>
+        <span class="topbar__title">OpenAI Mega App</span>
+      </div>
+      <div class="topbar__actions">
+        <button id="studio-toggle" class="btn btn--ghost" type="button">
+          <span>Studio</span>
+        </button>
+      </div>
+    </header>
+
     <header class="hero">
       <div class="hero__content">
         <h1>OpenAI Mega App</h1>
         <p>
           A product-minded playground showcasing the latest OpenAI APIs, rich conversation
-          management, and a generative gallery backed by SQLite.
+          management, and a generative studio backed by SQLite.
         </p>
         <button id="new-conversation" class="btn btn--primary">New Conversation</button>
       </div>
@@ -42,27 +54,211 @@
         </form>
       </section>
 
-      <section class="panel">
-        <h2>Generative Gallery</h2>
-        <form id="image-form" class="image-form">
-          <input id="image-prompt" type="text" placeholder="Dream up an illustration..." />
-          <div class="image-form__controls">
-            <select id="image-size">
-              <option value="1024x1024">1024x1024</option>
-              <option value="512x512">512x512</option>
-              <option value="256x256">256x256</option>
+      <section class="panel panel--gallery">
+        <div class="panel__header">
+          <h2>Generative Feed</h2>
+          <div class="feed-controls">
+            <input
+              id="feed-search"
+              type="search"
+              placeholder="Search generated assets..."
+              aria-label="Search generated assets"
+            />
+            <select id="feed-type-filter" aria-label="Filter by asset type">
+              <option value="all">All assets</option>
+              <option value="image">Images</option>
+              <option value="video">Videos</option>
             </select>
-            <select id="image-quality">
-              <option value="high">High</option>
-              <option value="medium">Medium</option>
-              <option value="low">Low</option>
-            </select>
-            <button type="submit" class="btn">Generate</button>
           </div>
-        </form>
+        </div>
         <div id="gallery" class="gallery"></div>
       </section>
     </main>
+
+    <section id="studio" class="studio" aria-hidden="true">
+      <div class="studio__surface">
+        <header class="studio__header">
+          <div>
+            <p class="studio__eyebrow">Creator Tools</p>
+            <h2>Studio Workspace</h2>
+          </div>
+          <div class="studio__header-actions">
+            <button id="studio-close" class="btn" type="button">Close</button>
+          </div>
+        </header>
+        <div class="studio__body">
+          <aside class="studio__sidebar" aria-label="Studio navigation">
+            <button class="studio__nav-btn is-active" data-view="generate" type="button">
+              Generate
+            </button>
+            <button class="studio__nav-btn" data-view="gallery" type="button">Gallery</button>
+            <button class="studio__nav-btn" data-view="composer" type="button">Studio</button>
+          </aside>
+          <div class="studio__workspace">
+            <section
+              id="studio-view-generate"
+              class="studio-view is-active"
+              data-view="generate"
+            >
+              <header class="studio-view__header">
+                <h3>Create images &amp; motion</h3>
+                <p>Craft prompts, tweak aspect ratios, and publish straight to your feed.</p>
+              </header>
+              <form id="studio-generate-form" class="studio-form">
+                <label class="studio-field">
+                  <span>Prompt</span>
+                  <textarea
+                    id="studio-prompt"
+                    placeholder="Imagine a cinematic product launch storyboard..."
+                    required
+                  ></textarea>
+                </label>
+                <div class="studio-form__grid">
+                  <label class="studio-field">
+                    <span>Asset type</span>
+                    <select id="studio-asset-type">
+                      <option value="image">Image</option>
+                      <option value="video">Video</option>
+                    </select>
+                  </label>
+                  <label class="studio-field">
+                    <span>Size</span>
+                    <select id="studio-size">
+                      <option value="1024x1024">1024 × 1024</option>
+                      <option value="512x512">512 × 512</option>
+                      <option value="256x256">256 × 256</option>
+                    </select>
+                  </label>
+                  <label class="studio-field">
+                    <span>Aspect ratio</span>
+                    <select id="studio-aspect">
+                      <option value="1:1">1:1</option>
+                      <option value="16:9">16:9</option>
+                      <option value="9:16">9:16</option>
+                      <option value="4:5">4:5</option>
+                    </select>
+                  </label>
+                  <label class="studio-field">
+                    <span>Quality</span>
+                    <select id="studio-quality">
+                      <option value="high">High</option>
+                      <option value="medium">Medium</option>
+                      <option value="low">Low</option>
+                    </select>
+                  </label>
+                  <label class="studio-field" id="studio-duration-field">
+                    <span>Duration (seconds)</span>
+                    <input id="studio-duration" type="number" value="8" min="2" max="60" />
+                  </label>
+                </div>
+                <div class="studio-form__actions">
+                  <button type="submit" class="btn btn--primary">Generate asset</button>
+                  <p class="studio-form__hint">All outputs are saved to the main feed automatically.</p>
+                </div>
+              </form>
+            </section>
+
+            <section id="studio-view-gallery" class="studio-view" data-view="gallery">
+              <header class="studio-view__header">
+                <h3>Manage galleries</h3>
+                <p>Create custom, on-brand collections and keep them searchable.</p>
+              </header>
+              <form id="studio-gallery-form" class="studio-form studio-form--inline">
+                <label class="studio-field">
+                  <span>Name</span>
+                  <input id="studio-gallery-name" type="text" placeholder="Summer campaign" required />
+                </label>
+                <label class="studio-field">
+                  <span>Category</span>
+                  <input id="studio-gallery-category" type="text" placeholder="Launch" />
+                </label>
+                <label class="studio-field">
+                  <span>Accent color</span>
+                  <input id="studio-gallery-color" type="color" value="#10a37f" />
+                </label>
+                <label class="studio-field">
+                  <span>Layout</span>
+                  <select id="studio-gallery-layout">
+                    <option value="grid">Grid</option>
+                    <option value="masonry">Masonry</option>
+                    <option value="filmstrip">Filmstrip</option>
+                  </select>
+                </label>
+                <label class="studio-field studio-field--wide">
+                  <span>Description</span>
+                  <input
+                    id="studio-gallery-description"
+                    type="text"
+                    placeholder="Hero imagery for Q3 growth campaign"
+                  />
+                </label>
+                <button type="submit" class="btn btn--primary">Create gallery</button>
+              </form>
+
+              <div class="studio-gallery__controls">
+                <input
+                  id="studio-gallery-search"
+                  type="search"
+                  placeholder="Search galleries"
+                />
+                <select id="studio-gallery-filter">
+                  <option value="all">All categories</option>
+                </select>
+              </div>
+              <div id="studio-gallery-list" class="studio-gallery__list"></div>
+            </section>
+
+            <section id="studio-view-composer" class="studio-view" data-view="composer">
+              <header class="studio-view__header">
+                <h3>Video studio</h3>
+                <p>Import gallery visuals, arrange scenes, and publish a final video.</p>
+              </header>
+              <form id="studio-composer-form" class="studio-form studio-form--inline">
+                <label class="studio-field">
+                  <span>Title</span>
+                  <input id="composer-title" type="text" placeholder="Vertical launch reel" />
+                </label>
+                <label class="studio-field">
+                  <span>Orientation</span>
+                  <select id="composer-orientation">
+                    <option value="vertical">Vertical</option>
+                    <option value="landscape">Landscape</option>
+                  </select>
+                </label>
+                <label class="studio-field studio-field--wide">
+                  <span>Description</span>
+                  <input id="composer-description" type="text" placeholder="Optional treatment notes" />
+                </label>
+              </form>
+              <div class="studio-composer">
+                <div class="studio-composer__library">
+                  <div class="studio-composer__library-header">
+                    <h4>Source library</h4>
+                    <select id="composer-gallery-select">
+                      <option value="feed">Main feed</option>
+                    </select>
+                  </div>
+                  <div id="composer-library" class="studio-composer__grid"></div>
+                </div>
+                <div class="studio-composer__timeline">
+                  <div class="studio-composer__timeline-header">
+                    <h4>Timeline</h4>
+                    <button id="composer-clear" type="button" class="btn">Clear</button>
+                  </div>
+                  <ol id="composer-timeline" class="studio-composer__timeline-list"></ol>
+                  <button id="composer-render" class="btn btn--primary" type="button">
+                    Render final video
+                  </button>
+                  <p class="studio-form__hint">
+                    The rendered video will appear in your main feed and can be added to any gallery.
+                  </p>
+                </div>
+              </div>
+            </section>
+          </div>
+        </div>
+      </div>
+    </section>
 
     <footer class="footer">
       <p>


### PR DESCRIPTION
## Summary
- introduce gallery collections and a video storyboard pipeline to the backend, including image aspect ratio metadata and a studio render endpoint
- add a dedicated studio workspace UI with navigation, generation tools, gallery management, and a video composer surfaced from a new top navigation button
- refresh styling and client logic to support filtering, gallery assignment, and studio workflows across the main feed and composer

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68e464da5db48329b122f5e559c7638e