### PR TITLE
Refactor layout into draggable widget canvas

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -12,6 +12,10 @@ class ConversationCreate(BaseModel):
     title: str = Field(..., min_length=1, max_length=255)
 
 
+class ConversationUpdate(BaseModel):
+    title: str = Field(..., min_length=1, max_length=255)
+
+
 class ConversationRead(BaseModel):
     id: int
     title: str

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -54,6 +54,55 @@ body {
   gap: 0.75rem;
 }
 
+.dropdown {
+  position: relative;
+}
+
+.dropdown__caret {
+  margin-left: 0.35rem;
+  font-size: 0.8rem;
+}
+
+.dropdown__menu {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 0.5rem);
+  display: grid;
+  background: rgba(15, 23, 42, 0.92);
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  padding: 0.5rem;
+  min-width: 220px;
+  box-shadow: 0 20px 45px rgba(8, 11, 18, 0.45);
+  opacity: 0;
+  transform: translateY(-8px);
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  z-index: 10;
+}
+
+.dropdown.is-open .dropdown__menu {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.dropdown__item {
+  background: transparent;
+  border: none;
+  color: var(--text);
+  text-align: left;
+  padding: 0.65rem 0.75rem;
+  border-radius: 0.6rem;
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.dropdown__item:hover {
+  background: rgba(59, 130, 246, 0.15);
+  color: #fff;
+}
+
 .hero {
   padding: 3rem clamp(2rem, 6vw, 6rem);
   display: flex;
@@ -87,36 +136,231 @@ body {
   letter-spacing: 0.04em;
 }
 
-.layout {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 1.5rem;
-  padding: 0 clamp(1.5rem, 4vw, 4rem) 4rem;
-}
-
-.panel {
-  background: var(--panel);
-  border: 1px solid var(--border);
-  border-radius: 1.5rem;
-  padding: 1.5rem;
-  backdrop-filter: blur(16px);
-  min-height: 420px;
+.workspace {
+  padding: 0 clamp(1.5rem, 4vw, 4rem) 3rem;
   display: flex;
   flex-direction: column;
+  gap: 1.25rem;
 }
 
-.panel h2 {
-  margin-top: 0;
-  margin-bottom: 1rem;
-  font-size: 1.3rem;
-}
-
-.panel__header {
+.canvas-controls {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 0.5rem 1.25rem;
+  backdrop-filter: blur(18px);
+}
+
+.canvas-controls__group {
+  display: flex;
+  align-items: center;
   gap: 1rem;
-  margin-bottom: 1.25rem;
+}
+
+.canvas-controls__label {
+  font-weight: 600;
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+
+.canvas-controls__buttons {
+  display: inline-flex;
+  gap: 0.5rem;
+}
+
+.canvas-controls__btn {
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 50%;
+  border: 1px solid var(--border);
+  background: rgba(10, 14, 22, 0.7);
+  color: var(--text);
+  cursor: pointer;
+  font-weight: 600;
+  transition: border-color 0.2s ease, color 0.2s ease;
+}
+
+.canvas-controls__btn:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.canvas-controls__value {
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.canvas-wrapper {
+  position: relative;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 1.5rem;
+  overflow: hidden;
+  background: rgba(9, 12, 18, 0.65);
+  min-height: clamp(600px, 70vh, 840px);
+}
+
+.canvas {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  overflow: auto;
+}
+
+.canvas__content {
+  position: relative;
+  min-width: 1600px;
+  min-height: 900px;
+  transform-origin: 0 0;
+  transition: transform 0.1s ease;
+}
+
+.widget {
+  position: absolute;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  backdrop-filter: blur(14px);
+  box-shadow: 0 30px 65px rgba(8, 12, 20, 0.55);
+}
+
+.widget__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.9rem 1.1rem;
+  background: rgba(15, 23, 42, 0.65);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.22);
+  cursor: grab;
+  user-select: none;
+}
+
+.widget__header:active {
+  cursor: grabbing;
+}
+
+.widget__title {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.widget__toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.widget__body {
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  overflow: auto;
+  flex: 1;
+}
+
+.widget-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.widget-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+}
+
+.widget-field span {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+}
+
+.widget-field textarea,
+.widget-field select,
+.widget-field input {
+  border-radius: 0.85rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.6);
+  color: var(--text);
+  padding: 0.65rem 0.85rem;
+  font: inherit;
+}
+
+.widget-form__row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0.75rem;
+}
+
+.widget__hint {
+  color: var(--muted);
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.widget-note {
+  min-height: 100px;
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.55);
+  color: var(--text);
+  padding: 0.75rem 1rem;
+  resize: vertical;
+}
+
+.widget__icon {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 0.6rem;
+  border: 1px solid transparent;
+  background: rgba(148, 163, 184, 0.12);
+  color: var(--text);
+  cursor: pointer;
+  font-size: 1rem;
+  display: grid;
+  place-items: center;
+  transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.widget__icon:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.widget__resize {
+  position: absolute;
+  width: 18px;
+  height: 18px;
+  right: 0;
+  bottom: 0;
+  cursor: nwse-resize;
+  background: linear-gradient(135deg, transparent 55%, rgba(16, 163, 127, 0.6));
+}
+
+.widget.is-minimized .widget__body {
+  display: none;
+}
+
+.widget.is-minimized {
+  height: auto !important;
+}
+
+.btn--sm {
+  padding: 0.45rem 0.85rem;
+  font-size: 0.85rem;
+  border-radius: 0.75rem;
 }
 
 .feed-controls {
@@ -180,18 +424,60 @@ body {
 }
 
 .conversation-list li {
-  padding: 0.75rem 1rem;
-  border-radius: 1rem;
+  padding: 0.65rem 0.8rem;
+  border-radius: 0.9rem;
   border: 1px solid transparent;
   background: rgba(255, 255, 255, 0.02);
-  cursor: pointer;
-  transition: border-color 0.2s ease, background 0.2s ease;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
 }
 
 .conversation-list li.active,
 .conversation-list li:hover {
   border-color: var(--accent);
   background: rgba(16, 163, 127, 0.1);
+}
+
+.conversation-list__title {
+  flex: 1;
+  font-weight: 500;
+  cursor: pointer;
+  background: transparent;
+  border: none;
+  color: inherit;
+  text-align: left;
+  padding: 0;
+  font: inherit;
+}
+
+.conversation-list__actions {
+  display: inline-flex;
+  gap: 0.35rem;
+}
+
+.conversation-list__title:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.conversation-list__btn {
+  width: 1.8rem;
+  height: 1.8rem;
+  border-radius: 0.5rem;
+  border: 1px solid transparent;
+  background: rgba(15, 23, 42, 0.55);
+  color: var(--muted);
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  font-size: 0.85rem;
+}
+
+.conversation-list__btn:hover {
+  border-color: var(--accent);
+  color: var(--accent);
 }
 
 .chat-thread {
@@ -688,6 +974,63 @@ body {
   font-size: 0.9rem;
 }
 
+.agents {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(4, 7, 12, 0.78);
+  backdrop-filter: blur(18px);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s ease;
+  z-index: 40;
+}
+
+.agents.is-open {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.agents__surface {
+  width: min(960px, 90vw);
+  min-height: 60vh;
+  border-radius: 2rem;
+  background: rgba(11, 15, 22, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  display: flex;
+  flex-direction: column;
+  padding: 2.5rem;
+  gap: 2rem;
+  color: var(--text);
+  box-shadow: 0 40px 80px rgba(5, 8, 14, 0.5);
+}
+
+.agents__header h2 {
+  margin: 0 0 0.5rem;
+  font-size: 2rem;
+}
+
+.agents__header p {
+  color: var(--muted);
+}
+
+.agents__body {
+  flex: 1;
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+  border-radius: 1.5rem;
+  display: grid;
+  place-items: center;
+  background: rgba(13, 18, 28, 0.6);
+}
+
+.agents__placeholder p {
+  color: rgba(226, 232, 240, 0.7);
+  font-size: 1.2rem;
+  text-align: center;
+}
+
 @keyframes fade-in {
   from {
     opacity: 0;
@@ -700,17 +1043,27 @@ body {
 }
 
 @media (max-width: 900px) {
-  .layout {
-    grid-template-columns: 1fr;
+  .canvas__content {
+    min-width: 1200px;
   }
 }
 
 @media (max-width: 768px) {
-  .chat-form__controls {
+  .canvas-controls {
     flex-direction: column;
-    align-items: stretch;
+    align-items: flex-start;
+    gap: 0.75rem;
   }
 
+  .canvas-controls__value {
+    align-self: flex-end;
+  }
+
+  .canvas__content {
+    min-width: 960px;
+  }
+
+  .chat-form__controls,
   .feed-controls {
     flex-direction: column;
     align-items: stretch;

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -14,6 +14,25 @@
         <span class="topbar__title">OpenAI Mega App</span>
       </div>
       <div class="topbar__actions">
+        <div class="dropdown" data-dropdown>
+          <button
+            id="add-widget"
+            class="btn btn--ghost"
+            type="button"
+            aria-haspopup="menu"
+            aria-expanded="false"
+          >
+            Add Widget
+            <span class="dropdown__caret" aria-hidden="true">▾</span>
+          </button>
+          <div class="dropdown__menu" role="menu" aria-hidden="true">
+            <button class="dropdown__item" data-widget-type="chat" type="button">New chat workspace</button>
+            <button class="dropdown__item" data-widget-type="image" type="button">Image generator</button>
+            <button class="dropdown__item" data-widget-type="video" type="button">Video generator</button>
+            <button class="dropdown__item" data-widget-type="world" type="button">3D world creator</button>
+          </div>
+        </div>
+        <button id="agents-toggle" class="btn btn--ghost" type="button">Agents</button>
         <button id="studio-toggle" class="btn btn--ghost" type="button">
           <span>Studio</span>
         </button>
@@ -27,53 +46,124 @@
           A product-minded playground showcasing the latest OpenAI APIs, rich conversation
           management, and a generative studio backed by SQLite.
         </p>
-        <button id="new-conversation" class="btn btn--primary">New Conversation</button>
       </div>
       <div class="hero__badge">API-first · Product Ready · PM Portfolio</div>
     </header>
 
-    <main class="layout">
-      <section class="panel">
-        <h2>Conversations</h2>
-        <ul id="conversation-list" class="conversation-list"></ul>
-      </section>
-
-      <section class="panel">
-        <h2>Chat Workspace</h2>
-        <div id="chat-thread" class="chat-thread"></div>
-        <form id="chat-form" class="chat-form">
-          <textarea id="chat-input" placeholder="Ask anything about your next product milestone..."></textarea>
-          <div class="chat-form__controls">
-            <select id="model-select">
-              <option value="gpt-5-chat-latest" selected>gpt-5-chat-latest</option>
-              <option value="gpt-4.1">gpt-4.1</option>
-              <option value="gpt-4.1-mini">gpt-4.1-mini</option>
-              <option value="o4-mini">o4-mini</option>
-            </select>
-            <button type="submit" class="btn btn--primary">Send</button>
-          </div>
-        </form>
-      </section>
-
-      <section class="panel panel--gallery">
-        <div class="panel__header">
-          <h2>Generative Feed</h2>
-          <div class="feed-controls">
-            <input
-              id="feed-search"
-              type="search"
-              placeholder="Search generated assets..."
-              aria-label="Search generated assets"
-            />
-            <select id="feed-type-filter" aria-label="Filter by asset type">
-              <option value="all">All assets</option>
-              <option value="image">Images</option>
-              <option value="video">Videos</option>
-            </select>
+    <main class="workspace">
+      <div class="canvas-controls">
+        <div class="canvas-controls__group">
+          <span class="canvas-controls__label">Canvas zoom</span>
+          <div class="canvas-controls__buttons">
+            <button class="canvas-controls__btn" data-zoom="out" type="button" aria-label="Zoom out">−</button>
+            <button class="canvas-controls__btn" data-zoom="reset" type="button">Reset</button>
+            <button class="canvas-controls__btn" data-zoom="in" type="button" aria-label="Zoom in">+</button>
           </div>
         </div>
-        <div id="gallery" class="gallery"></div>
-      </section>
+        <span id="zoom-indicator" class="canvas-controls__value">100%</span>
+      </div>
+      <div id="canvas-wrapper" class="canvas-wrapper">
+        <div id="canvas" class="canvas">
+          <div id="canvas-content" class="canvas__content">
+            <section
+              id="widget-conversations"
+              class="widget"
+              data-widget
+              data-lock-close="true"
+              style="width: 320px; height: 460px; left: 24px; top: 24px;"
+            >
+              <header class="widget__header" data-drag-handle>
+                <h2 class="widget__title">Conversations</h2>
+                <div class="widget__toolbar">
+                  <button id="new-conversation" class="btn btn--primary btn--sm" type="button">
+                    New conversation
+                  </button>
+                  <button class="widget__icon" data-action="minimize" type="button" aria-label="Minimize">
+                    ▭
+                  </button>
+                </div>
+              </header>
+              <div class="widget__body">
+                <ul id="conversation-list" class="conversation-list"></ul>
+              </div>
+              <div class="widget__resize" data-resize aria-hidden="true"></div>
+            </section>
+
+            <section
+              id="widget-chat"
+              class="widget"
+              data-widget
+              style="width: 520px; height: 520px; left: 380px; top: 80px;"
+              data-widget-type="chat"
+            >
+              <header class="widget__header" data-drag-handle>
+                <h2 class="widget__title">Chat workspace</h2>
+                <div class="widget__toolbar">
+                  <button class="widget__icon" data-action="minimize" type="button" aria-label="Minimize">
+                    ▭
+                  </button>
+                  <button class="widget__icon" data-action="close" type="button" aria-label="Close">
+                    ✕
+                  </button>
+                </div>
+              </header>
+              <div class="widget__body">
+                <div id="chat-thread" class="chat-thread"></div>
+                <form id="chat-form" class="chat-form">
+                  <textarea
+                    id="chat-input"
+                    placeholder="Ask anything about your next product milestone..."
+                  ></textarea>
+                  <div class="chat-form__controls">
+                    <select id="model-select">
+                      <option value="gpt-5-chat-latest" selected>gpt-5-chat-latest</option>
+                      <option value="gpt-4.1">gpt-4.1</option>
+                      <option value="gpt-4.1-mini">gpt-4.1-mini</option>
+                      <option value="o4-mini">o4-mini</option>
+                    </select>
+                    <button type="submit" class="btn btn--primary">Send</button>
+                  </div>
+                </form>
+              </div>
+              <div class="widget__resize" data-resize aria-hidden="true"></div>
+            </section>
+
+            <section
+              id="widget-feed"
+              class="widget"
+              data-widget
+              style="width: 480px; height: 480px; left: 960px; top: 60px;"
+              data-widget-type="feed"
+            >
+              <header class="widget__header" data-drag-handle>
+                <h2 class="widget__title">Generative feed</h2>
+                <div class="widget__toolbar">
+                  <button class="widget__icon" data-action="minimize" type="button" aria-label="Minimize">
+                    ▭
+                  </button>
+                </div>
+              </header>
+              <div class="widget__body">
+                <div class="feed-controls">
+                  <input
+                    id="feed-search"
+                    type="search"
+                    placeholder="Search generated assets..."
+                    aria-label="Search generated assets"
+                  />
+                  <select id="feed-type-filter" aria-label="Filter by asset type">
+                    <option value="all">All assets</option>
+                    <option value="image">Images</option>
+                    <option value="video">Videos</option>
+                  </select>
+                </div>
+                <div id="gallery" class="gallery"></div>
+              </div>
+              <div class="widget__resize" data-resize aria-hidden="true"></div>
+            </section>
+          </div>
+        </div>
+      </div>
     </main>
 
     <section id="studio" class="studio" aria-hidden="true">
@@ -256,6 +346,21 @@
                 </div>
               </div>
             </section>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="agents" class="agents" aria-hidden="true">
+      <div class="agents__surface">
+        <header class="agents__header">
+          <h2>Agents workspace</h2>
+          <p>A blank canvas for your future agent tools.</p>
+          <button id="agents-close" class="btn" type="button">Close</button>
+        </header>
+        <div class="agents__body">
+          <div class="agents__placeholder">
+            <p>Design your agent orchestration tools here.</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- convert the landing page into a zoomable canvas with draggable widgets, an add-widget menu, and an Agents surface
- extend the frontend logic to support widget creation, movement, resizing, conversation editing/deleting, and generator utilities
- add FastAPI endpoints and schemas so conversation titles can be renamed or removed from the database

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e474446a4c832996d89b8308fbe53d