### PR TITLE
Enhance widget input styling

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -7,6 +7,10 @@
   --text: #f8fafc;
   --muted: #94a3b8;
   --border: rgba(148, 163, 184, 0.25);
+  --input-bg: linear-gradient(145deg, rgba(15, 23, 42, 0.9), rgba(30, 41, 59, 0.85));
+  --input-border: rgba(148, 163, 184, 0.45);
+  --input-highlight: rgba(59, 130, 246, 0.85);
+  --input-glow: rgba(59, 130, 246, 0.25);
   font-family: "Inter", system-ui, sans-serif;
 }
 
@@ -356,12 +360,35 @@ body {
 .widget-field textarea,
 .widget-field select,
 .widget-field input {
-  border-radius: 0.85rem;
-  border: 1px solid rgba(148, 163, 184, 0.35);
-  background: rgba(15, 23, 42, 0.6);
+  border-radius: 1rem;
+  border: 1px solid var(--input-border);
+  background: var(--input-bg);
   color: var(--text);
-  padding: 0.65rem 0.85rem;
+  padding: 0.75rem 1rem;
   font: inherit;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04), 0 12px 35px rgba(8, 11, 18, 0.55);
+  backdrop-filter: blur(12px);
+  transition: border-color 0.25s ease, box-shadow 0.3s ease, transform 0.2s ease;
+  outline: none;
+}
+
+.widget-field textarea::placeholder,
+.widget-field input::placeholder {
+  color: rgba(148, 163, 184, 0.6);
+}
+
+.widget-field textarea:hover,
+.widget-field select:hover,
+.widget-field input:hover {
+  border-color: rgba(148, 163, 184, 0.65);
+}
+
+.widget-field textarea:focus,
+.widget-field select:focus,
+.widget-field input:focus {
+  border-color: var(--input-highlight);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 0 0 2px var(--input-glow), 0 18px 40px rgba(15, 118, 110, 0.35);
+  transform: translateY(-1px);
 }
 
 .widget-form__row {
@@ -890,12 +917,30 @@ body {
 .chat-form textarea {
   resize: vertical;
   min-height: 120px;
-  border-radius: 1rem;
-  border: 1px solid var(--border);
-  background: rgba(15, 23, 42, 0.65);
-  padding: 1rem;
+  border-radius: 1.25rem;
+  border: 1px solid var(--input-border);
+  background: var(--input-bg);
+  padding: 1.1rem 1.25rem;
   color: var(--text);
   font-size: 1rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05), 0 16px 40px rgba(8, 11, 18, 0.6);
+  backdrop-filter: blur(14px);
+  transition: border-color 0.25s ease, box-shadow 0.3s ease, transform 0.2s ease;
+  outline: none;
+}
+
+.chat-form textarea::placeholder {
+  color: rgba(148, 163, 184, 0.6);
+}
+
+.chat-form textarea:hover {
+  border-color: rgba(148, 163, 184, 0.65);
+}
+
+.chat-form textarea:focus {
+  border-color: var(--input-highlight);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1), 0 0 0 2px var(--input-glow), 0 22px 50px rgba(37, 99, 235, 0.35);
+  transform: translateY(-1px);
 }
 
 .chat-form__controls {
@@ -907,11 +952,21 @@ body {
 
 .chat-form select {
   border-radius: 999px;
-  border: 1px solid var(--border);
-  background: rgba(15, 23, 42, 0.65);
-  padding: 0.6rem 1rem;
+  border: 1px solid var(--input-border);
+  background: var(--input-bg);
+  padding: 0.65rem 1.1rem;
   color: var(--text);
-  font-weight: 500;
+  font-weight: 600;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05), 0 12px 30px rgba(8, 11, 18, 0.45);
+  transition: border-color 0.25s ease, box-shadow 0.3s ease, transform 0.2s ease;
+}
+
+.chat-form select:focus,
+.chat-form select:hover {
+  border-color: var(--input-highlight);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 0 0 2px var(--input-glow), 0 18px 40px rgba(15, 118, 110, 0.3);
+  outline: none;
+  transform: translateY(-1px);
 }
 
 .gallery {


### PR DESCRIPTION
## Summary
- add reusable CSS variables for widget input surfaces
- refresh widget inputs, selects, and chat textarea with gradient backgrounds, glow borders, and focus states
- update chat controls to share the richer styling treatment

## Testing
- uvicorn app.main:app --host 0.0.0.0 --port 8000

------
https://chatgpt.com/codex/tasks/task_e_68f6905822588329ae32d7f2847050bc